### PR TITLE
feat: commitlint config support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const SUPPORT_LINTER = [
 	"eslint.json",
 	"prettier.json",
 	"stylelint.json",
+	"commitlint.json",
 ];
 export const SUPPORT_CONFIG_KEYS = ["alias:string", "autoMatch?:boolean"];
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,10 +100,12 @@ export function parseNpmPackages(linter: string, json: string, alias: string) {
 	const aliases = JSON.parse(alias);
 	const npmPackages = [
 		...(parsed.extends?.filter((plugin: string) => isNpmPackage(plugin)) ||
-			[]), // eslint and prettier(extends)
+			[]), // eslint, prettier(extra extends), stylelint
 		...(parsed.plugins?.filter((plugin: string) => isNpmPackage(plugin)) ||
 			[]), // eslint
 		...(parsed.parser || []), // eslint(only one, @typescript-eslint/parser)
+		...(parsed.parserPreset || []), // commitlint
+		...(parsed.formatter || []), // stylelint
 	];
 	if (json.includes("@typescript-eslint")) {
 		npmPackages.push("@typescript-eslint/eslint-plugin");
@@ -117,6 +119,9 @@ export function parseNpmPackages(linter: string, json: string, alias: string) {
 			break;
 		case "stylelint.json":
 			npmPackages.push("stylelint");
+			break;
+		case "commitlint.json":
+			npmPackages.push("@commitlint/cli");
 			break;
 	}
 	if (aliases) {


### PR DESCRIPTION
### Description

**feature**: commitlint config support

**performance**: add 2 keys of parsing npm packages according to https://commitlint.js.org/#/reference-configuration: `parserPreset`, `formatter`

**performance**: auto install `@commitlint/cli` if commitlint.json exists. (https://commitlint.js.org/#/guides-local-setup)

**documemtation**: update support configs in #14 