### PR TITLE
perf: temp config support

### DIFF
--- a/src/actions/alias.ts
+++ b/src/actions/alias.ts
@@ -10,7 +10,7 @@ import {
 } from "../utils";
 import { CONFIG } from "../constants";
 import { boom } from "../error";
-import { select, text } from "src/prompts";
+import { select, text } from "../prompts";
 
 function consoleSource(filename: string) {
   console.log(`\nYou should restart your terminal to apply the changes`);

--- a/src/actions/main.ts
+++ b/src/actions/main.ts
@@ -23,7 +23,7 @@ import {
 } from "../request";
 import spawn from "cross-spawn";
 import { boom } from "../error";
-import { confirm, select } from "src/prompts";
+import { confirm, select } from "../prompts";
 
 export const main = async (argv: Iminimist) => {
   validateConfigConflict();

--- a/src/actions/origins.ts
+++ b/src/actions/origins.ts
@@ -4,7 +4,7 @@ import { Iminimist } from "../types";
 import { prettyStringify, userConfig, validateType } from "../utils";
 import { CONFIG } from "../constants";
 import { boom } from "../error";
-import { text } from "src/prompts";
+import { text } from "../prompts";
 
 function setConfig(
   type: string,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,10 @@
+import path from "path";
+import { __DEV__ } from "./utils";
 import { userHome } from "./utils/user";
-export const WLINT = `${userHome}/.config`;
+
+export const WLINT = __DEV__
+  ? `${userHome}/.wlint`
+  : `${path.resolve(process.cwd())}/temp`;
 export const CONFIG = `${WLINT}/.wlintrc.json`;
 export const ORIGINAL = `wibus-wee/wlint-config`;
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -50,6 +50,7 @@ export async function select(optsRaw: SelectProps) {
     name: "result",
     type: optsRaw.multiselect ? "multiselect" : "select",
     choices: [] as Array<prompts.Choice>,
+    message: optsRaw.message,
   };
   optsRaw.choices.forEach((choice) => {
     if (typeof choice === "string") {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,11 +1,17 @@
 import fs from "node:fs";
-import { CONFIG } from "../constants";
+import { CONFIG, WLINT } from "../constants";
 import { prettyStringify } from "./generator";
 
 export const __DEV__ = process.env.NODE_ENV === "development";
 
 export function getConfigFile() {
   // Auto create wlint config file
+  if (__DEV__) {
+    // check if temp folder exists
+    if (!fs.existsSync(WLINT)) {
+      fs.mkdirSync(WLINT);
+    }
+  }
   try {
     const file = fs.readFileSync(CONFIG, "utf8").toString();
     if (!file) {


### PR DESCRIPTION
### Description

**performance**: temp config support (for developers)

To use temp config dir, you should run: 

```
pnpm dev # unbuild --stub
pnpm start # NODE_ENV=development node index.js
```

temp config is stored in: `${process.cwd()}/temp/.wlintrc.json`